### PR TITLE
Fix support m0 build

### DIFF
--- a/FtpServer.h
+++ b/FtpServer.h
@@ -221,7 +221,8 @@
 //	#define ParameterIs( a ) ( ! strcmp_PF( parameter, PSTR( a )))
 #elif(FTP_SERVER_NETWORK_TYPE == NETWORK_WiFiNINA)
 
-	#include <WiFiNINA.h>
+	//#include <WiFiNINA.h>
+	#include <WiFi101.h>  // EmotiBit uses WiFi101. Including NINA gives compile errors as we do not use that library.  ToDo: Check if FTP server can be implemented on M0 with WiFi 101
 	#define FTP_CLIENT_NETWORK_CLASS WiFiClient
 	//#define FTP_CLIENT_NETWORK_SSL_CLASS WiFiSSLClient
 	#define FTP_SERVER_NETWORK_SERVER_CLASS WiFiServer

--- a/FtpServerKey.h
+++ b/FtpServerKey.h
@@ -105,7 +105,7 @@ https://github.com/arduino-libraries/Ethernet/issues/88
 
 // Arduino SAMD
 	#define DEFAULT_FTP_SERVER_NETWORK_TYPE_SAMD 		NETWORK_WiFiNINA
-	#define DEFAULT_STORAGE_TYPE_SAMD 					STORAGE_SD
+	#define DEFAULT_STORAGE_TYPE_SAMD 					STORAGE_SDFAT2
 #endif
 
 #define UTF8_SUPPORT

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EmotiBit SimpleFTPServer
-version=2.1.7+EmotiBit.0.0.1
+version=2.1.7+EmotiBit.0.0.2
 author=Nitin Nair <nitin@emotibit.com>
 maintainer=Nitin Nair <nitin@emotibit.com>
 sentence=Fork of SimpleFtpServer for EmotiBit


### PR DESCRIPTION
# Description
Added support for building EmotiBit firmware for Feather M0.

# Requirements
- None


# Issues Referenced
<!-- If Any -->
- None

# Documentation update
None

# Testing
<!--- The testing results should be added to the main PR behind this bug-fix/ feature-add -->
<!--- If another **linked PR** is the main PR for this bug-fix/ feature-add, you may then remove this testing section and add a link to the main PR here with the explicit statement "testing results added to PR(link)". -->

## Results
<!--- The main results should be recorded in the appropriate testing results sheet -->
- ✔️ EmotiBit Firmware compiles on Feather M0
- ✔️ EmotiBit Firmware compiles on Feather ESP32

