### PR TITLE
include file changes to enable pio compile

### DIFF
--- a/FtpServer.h
+++ b/FtpServer.h
@@ -28,6 +28,18 @@
 #include "WProgram.h"
 #endif
 
+// ToDo: PIO has a weird behavior where it is not able to find these core files if they are nested 
+// inside a #ifdef that needs evaluation. See line 216. Once the PIO issue is resolved, these explicit
+// includes can be removed since they are included downstream conditionally.
+// See https://community.platformio.org/t/platformio-ldf-inconsistent-behavior-with-finding-included-header-files/38896
+#ifdef ARDUINO_FEATHER_ESP32
+#include <WiFi.h>
+#include <SD.h>
+#elif defined ADAFRUIT_FEATHER_M0
+#include <WiFi101.h>
+#include <SdFat.h>
+#endif
+
 //
 //#if(NETWORK_ESP8266_SD == DEFAULT_FTP_SERVER_NETWORK_TYPE_ESP8266)
 //	#define ESP8266_GT_2_4_2_SD_STORAGE_SELECTED

--- a/examples/EmotiBit-FileTransferManager/platformio.ini
+++ b/examples/EmotiBit-FileTransferManager/platformio.ini
@@ -1,0 +1,24 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+lib_dir=../../../
+
+[env:adafruit_feather_esp32]
+;parity with ESP Arduino v2.0.7. check release notes: https://github.com/platformio/platform-espressif32/releases/tag/v6.1.0
+platform = espressif32 @6.1.0
+board = featheresp32 
+framework = arduino
+build_flags = 
+    -DARDUINO_FEATHER_ESP32
+; change MCU frequency
+board_build.f_cpu = 240000000L
+lib_ldf_mode = deep+
+

--- a/examples/EmotiBit-FileTransferManager/src/main.cpp
+++ b/examples/EmotiBit-FileTransferManager/src/main.cpp
@@ -2,7 +2,7 @@
 #include <FileTransferManager.h>
 
 const char* ssid = "NETWORK_NAME";
-const char* password = "NETWORK_PASSWORD";
+const char* password = "NETWORK_PASS";
 FileTransferManager fileTransferManager;
 
 // Definitions taken from EmotiBitVersionController.cpp
@@ -38,13 +38,15 @@ void setup() {
   // Choose based on EmotiBit version you are using
   //digitalWrite(EMOTIBIT_VDD_ENABLE_PIN, LOW); // for EmotiBit V2
   digitalWrite(EMOTIBIT_VDD_ENABLE_PIN, HIGH); // for EmotiBit V3+
-  delay(500);
+  delay(1000);
 
   if (SD.begin(EMOTIBIT_SD_CS_PIN)) {
       Serial.println("SD opened!");
-      //listDir(SD, "/", 0);
-      //ftpSrv.setCallback(_callback);
-      //ftpSrv.setTransferCallback(_transferCallback);
+  }
+  else
+  {
+    Serial.println("SD not initialized. Please check battery and SD card on EmotiBit");
+    while(1);
   }
   Serial.println("Setting Protocol");
   fileTransferManager.setProtocol(FileTransferManager::Protocol::FTP);

--- a/examples/EmotiBit-FileTransferManager/src/main.cpp
+++ b/examples/EmotiBit-FileTransferManager/src/main.cpp
@@ -38,7 +38,8 @@ void setup() {
   // Choose based on EmotiBit version you are using
   //digitalWrite(EMOTIBIT_VDD_ENABLE_PIN, LOW); // for EmotiBit V2
   digitalWrite(EMOTIBIT_VDD_ENABLE_PIN, HIGH); // for EmotiBit V3+
-  
+  delay(500);
+
   if (SD.begin(EMOTIBIT_SD_CS_PIN)) {
       Serial.println("SD opened!");
       //listDir(SD, "/", 0);

--- a/examples/EmotiBit-FileTransferManager/src/main.cpp
+++ b/examples/EmotiBit-FileTransferManager/src/main.cpp
@@ -54,6 +54,7 @@ void setup() {
   fileTransferManager.setFtpAuth("ftp", "ftp");
   Serial.println("Setting Mode");
   fileTransferManager.setMode(FileTransferManager::Mode::FILE_TRANSFER);
+  fileTransferManager.begin();
 }
 
 void loop() {

--- a/examples/EmotiBit-FileTransferManager/src/main.cpp
+++ b/examples/EmotiBit-FileTransferManager/src/main.cpp
@@ -1,0 +1,59 @@
+#include <Arduino.h>
+#include <FileTransferManager.h>
+
+const char* ssid = "NETWORK_NAME";
+const char* password = "NETWORK_PASSWORD";
+FileTransferManager fileTransferManager;
+
+// Definitions taken from EmotiBitVersionController.cpp
+// ToDo: move these definitions out of VersionController into a smaller header that can be included in examples
+#ifdef ARDUINO_FEATHER_ESP32
+const int EMOTIBIT_VDD_ENABLE_PIN = 32; // Enable emotibit power; ESP32 boards
+const int EMOTIBIT_SD_CS_PIN = 4; // Chip select pin on EmotiBit for ESP32 
+#elif defined ADAFRUIT_FEATHER_M0
+const int EMOTIBIT_VDD_ENABLE_PIN = 6; // Enable emotibit power; ESP32 boards
+const int EMOTIBIT_SD_CS_PIN = 19; // Chip select pin on EmotiBit for ESP32 
+#endif
+
+
+void setup() {
+  // put your setup code here, to run once:
+  Serial.begin(115200);
+  WiFi.begin(ssid, password);
+  Serial.println("");
+
+  // Wait for connection
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println("");
+  Serial.print("Connected to ");
+  Serial.println(ssid);
+  Serial.print("IP address: ");
+  Serial.println(WiFi.localIP());
+  
+  // Enable power on EmotiBit board
+  pinMode(EMOTIBIT_VDD_ENABLE_PIN, OUTPUT);
+  // Choose based on EmotiBit version you are using
+  //digitalWrite(EMOTIBIT_VDD_ENABLE_PIN, LOW); // for EmotiBit V2
+  digitalWrite(EMOTIBIT_VDD_ENABLE_PIN, HIGH); // for EmotiBit V3+
+  
+  if (SD.begin(EMOTIBIT_SD_CS_PIN)) {
+      Serial.println("SD opened!");
+      //listDir(SD, "/", 0);
+      //ftpSrv.setCallback(_callback);
+      //ftpSrv.setTransferCallback(_transferCallback);
+  }
+  Serial.println("Setting Protocol");
+  fileTransferManager.setProtocol(FileTransferManager::Protocol::FTP);
+  Serial.println("Setting Auth");
+  fileTransferManager.setFtpAuth("ftp", "ftp");
+  Serial.println("Setting Mode");
+  fileTransferManager.setMode(FileTransferManager::Mode::FILE_TRANSFER);
+}
+
+void loop() {
+  // put your main code here, to run repeatedly:
+  fileTransferManager.handleTransfer();
+}

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EmotiBit SimpleFTPServer
-version=2.1.7+EmotiBit.0.0.2
+version=2.1.7+EmotiBit.0.0.3
 author=Nitin Nair <nitin@emotibit.com>
 maintainer=Nitin Nair <nitin@emotibit.com>
 sentence=Fork of SimpleFtpServer for EmotiBit


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail -->
https://community.platformio.org/t/platformio-ldf-inconsistent-behavior-with-finding-included-header-files/38896

# Requirements
- None


# Issues Referenced
<!-- If Any -->
- PlatformIO doesn't compile this library with includes nested inside #ifdef that need pre-processor evaluation

# Documentation update
None

# Notes for Reviewer
- None.


# Testing
<!--- The testing results should be added to the main PR behind this bug-fix/ feature-add -->
<!--- If another **linked PR** is the main PR for this bug-fix/ feature-add, you may then remove this testing section and add a link to the main PR here with the explicit statement "testing results added to PR(link)". -->

## Results
<!--- The main results should be recorded in the appropriate testing results sheet -->
- ✔️ `example/EmotiBit-FileTransferManager` tested working.

## Feature Tests
<!--- For each test case, create a unit test in the `EmotiBit Feature Test Protocol` document. -->
<!--- For firmware, the corresponding results recorded in the `EmotiBit Feature Testing Results` sheet. -->
<!--- For software, the corresponding results are recorded in the `EmotiBit Software Testing Records` sheet. -->
<!--- Add the test heading from "EmotiBit Feature Test Protocol" here. -->
- FTP server example: EmotiBit-FileTransferManager


## Screenshots:
![image](https://github.com/EmotiBit/EmotiBit_SimpleFTPServer/assets/31810812/198ed54f-b91c-40de-9488-ee08f670981f)
![image](https://github.com/EmotiBit/EmotiBit_SimpleFTPServer/assets/31810812/a5536b3d-dc2c-4f46-9850-4ff20a4547c6)
![image](https://github.com/EmotiBit/EmotiBit_SimpleFTPServer/assets/31810812/e49f2b86-66d6-475d-aae0-762dcb0fd518)
